### PR TITLE
Bug where np.round returns numpy.float64

### DIFF
--- a/deepfashion2_api/PythonAPI/pycocotools/cocoeval.py
+++ b/deepfashion2_api/PythonAPI/pycocotools/cocoeval.py
@@ -541,8 +541,8 @@ class Params:
         self.imgIds = []
         self.catIds = []
         # np.arange causes trouble.  the data point on arange is slightly larger than the true value
-        self.iouThrs = np.linspace(.5, 0.95, np.round((0.95 - .5) / .05) + 1, endpoint=True)
-        self.recThrs = np.linspace(.0, 1.00, np.round((1.00 - .0) / .01) + 1, endpoint=True)
+        self.iouThrs = np.linspace(.5, 0.95, int(np.round((0.95 - .5) / .05) + 1), endpoint=True)
+        self.recThrs = np.linspace(.0, 1.00, int(np.round((1.00 - .0) / .01) + 1), endpoint=True)
         self.maxDets = [1, 10, 100]
         self.areaRng = [[0 ** 2, 1e5 ** 2], [0 ** 2, 32 ** 2], [32 ** 2, 96 ** 2], [96 ** 2, 1e5 ** 2]]
         self.areaRngLbl = ['all', 'small', 'medium', 'large']
@@ -552,8 +552,8 @@ class Params:
         self.imgIds = []
         self.catIds = []
         # np.arange causes trouble.  the data point on arange is slightly larger than the true value
-        self.iouThrs = np.linspace(.5, 0.95, np.round((0.95 - .5) / .05) + 1, endpoint=True)
-        self.recThrs = np.linspace(.0, 1.00, np.round((1.00 - .0) / .01) + 1, endpoint=True)
+        self.iouThrs = np.linspace(.5, 0.95, int(np.round((0.95 - .5) / .05) + 1), endpoint=True)
+        self.recThrs = np.linspace(.0, 1.00, int(np.round((1.00 - .0) / .01) + 1), endpoint=True)
         self.maxDets = [20]
         self.areaRng = [[0 ** 2, 1e5 ** 2], [32 ** 2, 96 ** 2], [96 ** 2, 1e5 ** 2]]
         self.areaRngLbl = ['all', 'medium', 'large']


### PR DESCRIPTION
Hi, 

This pull request fixes a bug that caused a TypeError in the setKpParams function of the cocoeval.py file when using Python 3.7 and NumPy 1.21.6. The error occurred due to the use of np.linspace with a numpy.float64 object as the number of sample points.

Error details:

```
File "path/to/anaconda3/envs/HRNet2/lib/python3.7/site-packages/pycocotools-2.0-py3.7-macosx-10.9-x86_64.egg/pycocotools/cocoeval.py", line 556, in setKpParams
    self.iouThrs = np.linspace(.5, 0.95, np.round((0.95 - .5) / .05) + 1, endpoint=True)
  File "<__array_function__ internals>", line 6, in linspace
  File "path/to/anaconda3/envs/HRNet2/lib/python3.7/site-packages/numpy/core/function_base.py", line 120, in linspace
    num = operator.index(num)
TypeError: 'numpy.float64' object cannot be interpreted as an integer
```

Environment:

    Python: 3.7
    NumPy: 1.21.6

To resolve this issue, I have modified the np.linspace call in the setKpParams/setDetParams function to ensure that an integer is provided as the number of sample points. This change should maintain compatibility with other NumPy versions as well.